### PR TITLE
Make username error more informative

### DIFF
--- a/src/Views/AccountView.vala
+++ b/src/Views/AccountView.vala
@@ -42,8 +42,6 @@ public class Installer.AccountView : AbstractInstallerView {
         var username_label = new Granite.HeaderLabel (_("Username"));
 
         username_entry = new ValidatedEntry ();
-        username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "dialog-information-symbolic");
-        username_entry.set_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY, _("Can only contain lower case letters, numbers and no spaces"));
 
         username_error_revealer = new ErrorRevealer (".");
         username_error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);

--- a/src/Views/AccountView.vala
+++ b/src/Views/AccountView.vala
@@ -181,7 +181,7 @@ public class Installer.AccountView : AbstractInstallerView {
             if (username_is_taken) {
                 username_error_revealer.label = _("Username is already taken");
             } else if (!username_is_valid) {
-                username_error_revealer.label = _("Username can only contain lowercase letters, numbers, and no spaces");
+                username_error_revealer.label = _("Username can only contain lowercase letters and numbers, without spaces");
             }
 
             username_error_revealer.reveal_child = true;

--- a/src/Views/AccountView.vala
+++ b/src/Views/AccountView.vala
@@ -41,8 +41,6 @@ public class Installer.AccountView : AbstractInstallerView {
         var username_label = new Granite.HeaderLabel (_("Username"));
 
         username_entry = new Gtk.Entry ();
-        username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "dialog-information-symbolic");
-        username_entry.set_icon_tooltip_text (Gtk.EntryIconPosition.SECONDARY, _("Can only contain lower case letters, numbers and no spaces"));
 
         username_error_revealer = new ErrorRevealer (".");
         username_error_revealer.label_widget.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
@@ -175,7 +173,7 @@ public class Installer.AccountView : AbstractInstallerView {
 
         if (username_entry_text == "") {
             username_error_revealer.reveal_child = false;
-            username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "dialog-information-symbolic");
+            username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, null);
         } else if (username_is_valid && !username_is_taken) {
             username_error_revealer.reveal_child = false;
             username_entry.set_icon_from_icon_name (Gtk.EntryIconPosition.SECONDARY, "process-completed-symbolic");
@@ -183,7 +181,7 @@ public class Installer.AccountView : AbstractInstallerView {
             if (username_is_taken) {
                 username_error_revealer.label = _("Username is already taken");
             } else if (!username_is_valid) {
-                username_error_revealer.label = _("Username is not valid");
+                username_error_revealer.label = _("Username can only contain lowercase letters, numbers, and no spaces");
             }
 
             username_error_revealer.reveal_child = true;


### PR DESCRIPTION
Instead of just saying that the username is "invalid", use the text that used to be a tooltip.

Since the username is automatically generated when you type in your real name, chances are this field will rarely be empty so the tooltip will probably never be seen.