### PR TITLE
Activate next button on variant widget enter

### DIFF
--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -76,6 +76,10 @@ public class KeyboardLayoutView : AbstractInstallerView {
             return ((VariantRow) row1).description.collate (((VariantRow) row2).description);
         });
 
+        input_variant_widget.variant_listbox.row_activated.connect (() => {
+            next_button.activate ();
+        });
+
         back_button.clicked.connect (() => ((Gtk.Stack) get_parent ()).visible_child = previous_view);
 
         next_button.clicked.connect (() => next_step ());

--- a/src/Views/LanguageView.vala
+++ b/src/Views/LanguageView.vala
@@ -67,6 +67,10 @@ public class Installer.LanguageView : AbstractInstallerView {
 
         lang_variant_widget = new VariantWidget ();
 
+        lang_variant_widget.variant_listbox.row_activated.connect (() => {
+            next_button.activate ();
+        });
+
         lang_variant_widget.main_listbox.set_sort_func ((row1, row2) => {
             var langrow1 = (LangRow) row1;
             var langrow2 = (LangRow) row2;

--- a/src/Widgets/VariantWidget.vala
+++ b/src/Widgets/VariantWidget.vala
@@ -33,6 +33,8 @@ public class VariantWidget : Gtk.Frame {
         main_scrolled.add (main_listbox);
 
         variant_listbox = new Gtk.ListBox ();
+        variant_listbox.activate_on_single_click = false;
+
         var variant_scrolled = new Gtk.ScrolledWindow (null, null);
         variant_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
         variant_scrolled.vexpand = true;


### PR DESCRIPTION
Same as https://github.com/elementary/installer/pull/356

Activates the next button when the variant widget is activated (either by double click or enter).

Single click activate is turned off here because after selecting a layout you may want to test your selection, so you don't necessarily want to change screens right after you make a selection