### PR TITLE
Add error dialogs to make debugging easier in greeter session

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -48,6 +48,10 @@ namespace Utils {
     public static void create_new_user (string fullname, string username, string password) {
         var permission = get_permission ();
 
+        string? primary_text = null;
+        string? error_message = null;
+        string secondary_text = _("Initial Setup could not create your user. Without it, you will not be able to log in and may need to reinstall the OS.");
+
         if (permission != null && permission.allowed) {
             try {
                 var user_manager = get_usermanager ();
@@ -61,35 +65,27 @@ namespace Utils {
                     });
                 }
             } catch (Error e) {
-                string error_text = "Creating User '%s' Failed".printf (username);
-                critical ("%s: %s", error_text, e.message);
-
-                var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                    error_text,
-                    _("Initial Setup could not create your user. Without it, you will not be able to log in and may need to reinstall the OS."),
-                    "dialog-error",
-                    Gtk.ButtonsType.CLOSE
-                );
-
-                error_dialog.show_error_details (e.message);
-                error_dialog.run ();
-                error_dialog.destroy ();
+                primary_text = _("Creating User '%s' Failed").printf (username);
+                error_message = e.message;
             }
         } else {
-            string error_text = "No Permission to Create User '%s'".printf (username);
-            critical (error_text);
+            primary_text = _("No Permission to Create User '%s'").printf (username);
+        }
 
+        if (primary_text != null) {
             var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                error_text,
-                _("Initial Setup could not create your user. Without it, you will not be able to log in and may need to reinstall the OS."),
+                primary_text,
+                secondary_text,
                 "dialog-error",
                 Gtk.ButtonsType.CLOSE
             );
 
+            if (error_message != null) {
+                error_dialog.show_error_details (error_message);
+            }
+
             error_dialog.run ();
             error_dialog.destroy ();
-
-            critical (error_text);
         }
     }
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -61,8 +61,26 @@ namespace Utils {
                     });
                 }
             } catch (Error e) {
-                critical ("Creation of user '%s' failed".printf (username));
+                string error_text = "Creation of user '%s' failed:".printf (username);
+
+                try {
+                    Process.spawn_command_line_async ("zenity --error --width=256 --text=\"%s\n\n<tt>%s</tt>\"".printf (error_text, e.message));
+                } catch (Error e) {
+                    critical ("Unable to launch error dialog: %s", e.message);
+                }
+
+                critical ("%s %s", error_text, e.message);
             }
+        } else {
+            string error_text = "No permission to create user.";
+
+            try {
+                Process.spawn_command_line_async ("zenity --error --width=128 --text=\"%s\"".printf (error_text));
+            } catch (Error e) {
+                critical ("Unable to launch error dialog: %s", e.message);
+            }
+
+            critical (error_text);
         }
     }
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -61,24 +61,33 @@ namespace Utils {
                     });
                 }
             } catch (Error e) {
-                string error_text = "Creation of user '%s' failed:".printf (username);
+                string error_text = "Creating User '%s' Failed".printf (username);
+                critical ("%s: %s", error_text, e.message);
 
-                try {
-                    Process.spawn_command_line_async ("zenity --error --width=256 --text=\"%s\n\n<tt>%s</tt>\"".printf (error_text, e.message));
-                } catch (Error e) {
-                    critical ("Unable to launch error dialog: %s", e.message);
-                }
+                var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                    error_text,
+                    _("Initial Setup could not create your user. Without it, you will not be able to log in and may need to reinstall the OS."),
+                    "dialog-error",
+                    Gtk.ButtonsType.CLOSE
+                );
 
-                critical ("%s %s", error_text, e.message);
+                error_dialog.show_error_details (e.message);
+                error_dialog.run ();
+                error_dialog.destroy ();
             }
         } else {
-            string error_text = "No permission to create user.";
+            string error_text = "No Permission to Create User '%s'".printf (username);
+            critical (error_text);
 
-            try {
-                Process.spawn_command_line_async ("zenity --error --width=128 --text=\"%s\"".printf (error_text));
-            } catch (Error e) {
-                critical ("Unable to launch error dialog: %s", e.message);
-            }
+            var error_dialog = new Granite.MessageDialog.with_image_from_icon_name (
+                error_text,
+                _("Initial Setup could not create your user. Without it, you will not be able to log in and may need to reinstall the OS."),
+                "dialog-error",
+                Gtk.ButtonsType.CLOSE
+            );
+
+            error_dialog.run ();
+            error_dialog.destroy ();
 
             critical (error_text);
         }


### PR DESCRIPTION
This just adds some simple Granite.MessageDialog error dialogs for a couple of error conditions to make debugging easier in a live greeter session.