### PR TITLE
KeyboardLayoutView: Set layout (only during session)

### DIFF
--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -78,29 +78,54 @@ public class KeyboardLayoutView : AbstractInstallerView {
             next_button.activate ();
         });
 
-        back_button.clicked.connect (() => ((Gtk.Stack) get_parent ()).visible_child = previous_view);
-
-        next_button.clicked.connect (() => {
+        input_variant_widget.variant_listbox.row_selected.connect (() => {
             unowned Gtk.ListBoxRow row = input_variant_widget.main_listbox.get_selected_row ();
             if (row != null) {
                 var layout = ((LayoutRow) row).layout;
                 unowned Configuration configuration = Configuration.get_default ();
                 configuration.keyboard_layout = layout.name;
+                string second_variant = layout.name;
 
                 unowned Gtk.ListBoxRow vrow = input_variant_widget.variant_listbox.get_selected_row ();
                 if (vrow != null) {
                     string variant = ((VariantRow) vrow).code;
                     configuration.keyboard_variant = variant;
+                    if (variant != null) {
+                        second_variant += "+%s".printf (variant);
+                    }
                 } else if (layout.variants.is_empty) {
                     configuration.keyboard_variant = null;
-                } else {
+                }
+
+                GLib.Variant first = new GLib.Variant.string ("xkb");
+                GLib.Variant second = new GLib.Variant.string (second_variant);
+                GLib.Variant result = new GLib.Variant.tuple ({first, second});
+
+                Variant[] elements = {};
+                elements += result;
+
+                GLib.Variant list = new GLib.Variant.array (new VariantType ("(ss)"), elements);
+
+                var settings = new Settings ("org.gnome.desktop.input-sources");
+                settings.set_value ("sources", list);
+                settings.set_uint ("current", 0);
+            }
+        });
+
+        back_button.clicked.connect (() => ((Gtk.Stack) get_parent ()).visible_child = previous_view);
+
+        next_button.clicked.connect (() => {
+            unowned Gtk.ListBoxRow vrow = input_variant_widget.variant_listbox.get_selected_row ();
+            if (vrow == null) {
+                unowned Gtk.ListBoxRow row = input_variant_widget.main_listbox.get_selected_row ();
+                if (row != null) {
                     row.activate ();
                     return;
+                } else {
+                    warning ("next_button enabled when no keyboard selected");
+                    next_button.sensitive = false;
+                    return;
                 }
-            } else {
-                warning ("next_button enabled when no keyboard selected");
-                next_button.sensitive = false;
-                return;
             }
 
             next_step ();


### PR DESCRIPTION
This does not fix applying the layout to the user after they've been created.

What this should do is set the configuration when a row is selected so that the preview is updated and also changes the layout during the current session so that typing to test settings should work and the new layout will be used in the next view