### PR TITLE
use secrets for git username and email in release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ jobs:
    - uses: actions/checkout@v1
    - uses: elementary/actions/release@master
      env:
-       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GIT_USER_TOKEN: "${{ secrets.GIT_USER_TOKEN }}"
+      GIT_USER_NAME: "${{ secrets.GIT_USER_NAME }}"
+      GIT_USER_EMAIL: "${{ secrets.GIT_USER_EMAIL }}"
      with:
        release_branch: 'juno'


### PR DESCRIPTION
This pr adds the env vars required for the release action to authenticate as a different git user, instead of the default github-actions user.