### PR TITLE
Fix disabled account after creation on focal

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -57,12 +57,7 @@ namespace Utils {
                 var user_manager = get_usermanager ();
                 if (user_manager != null) {
                     var created_user = user_manager.create_user (username, fullname, Act.UserAccountType.ADMINISTRATOR);
-
-                    user_manager.user_added.connect ((user) => {
-                        if (user == created_user) {
-                            created_user.set_password (password, "");
-                        }
-                    });
+                    created_user.set_password (password, "");
 
                     return created_user;
                 }


### PR DESCRIPTION
I'm not sure why this was done in the `user_added` signal initially, but it seems to cause some sort of race where it tries to set the pasword on the account too early. If we do it this way, we don't end up with locked accounts after creation on focal.