### PR TITLE
Give accountsservice modify permission

### DIFF
--- a/data/49-io.elementary.initial-setup.pkla
+++ b/data/49-io.elementary.initial-setup.pkla
@@ -1,6 +1,6 @@
 [Initial setup]
 Identity=unix-user:lightdm
-Action=org.freedesktop.accounts.user-administration
+Action=org.freedesktop.accounts.user-administration;io.elementary.pantheon.AccountsService.ModifyAny
 ResultAny=yes
 ResultInactive=yes
 ResultActive=yes


### PR DESCRIPTION
This is needed for initial-setup running under the lightdm user to be able to modify AccountsService keys belonging to other users (i.e. when we're setting up a keyboard layout before first logon)