### PR TITLE
Use language2locale to set new user's language

### DIFF
--- a/src/Helpers/LocaleHelper.vala
+++ b/src/Helpers/LocaleHelper.vala
@@ -158,6 +158,27 @@ namespace LocaleHelper {
         return lang_entries;
     }
 
+    public static async bool language2locale (string language, out string? locale) {
+        locale = null;
+
+        try {
+            var command = new GLib.Subprocess (
+                SubprocessFlags.STDOUT_PIPE,
+                "/usr/share/language-tools/language2locale",
+                language
+            );
+
+            yield command.communicate_utf8_async (null, null, out locale, null);
+            locale = locale.strip ();
+
+            return command.get_exit_status () == 0;
+        } catch (Error e) {
+            warning ("Error running language2locale, new user's language may be incorrect: %s", e.message);
+        }
+
+        return false;
+    }
+
     // Taken from the /usr/share/language-tools/main-countries script.
     public static string? get_main_country (string lang_prefix) {
         switch (lang_prefix) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -83,16 +83,29 @@ public class Installer.MainWindow : Hdy.Window {
 
     private void on_finish () {
         if (account_view.created != null) {
-            account_view.created.set_language (Configuration.get_default ().lang);
-
-            set_keyboard_layout.begin ((obj, res) => {
-                set_keyboard_layout.end (res);
+            set_keyboard_and_locale.begin ((obj, res) => {
+                set_keyboard_and_locale.end (res);
                 destroy ();
             });
         } else {
             destroy ();
         }
 
+    }
+
+    private async void set_keyboard_and_locale () {
+        yield set_keyboard_layout ();
+
+        string lang = Configuration.get_default ().lang;
+        string? locale = null;
+        bool success = yield LocaleHelper.language2locale (lang, out locale);
+
+        if (!success || locale == null || locale == "") {
+            warning ("Falling back to setting unconverted language as user's locale, may result in incorrect language");
+            account_view.created.set_language (lang);
+        } else {
+            account_view.created.set_language (locale);
+        }
     }
 
     private async void set_keyboard_layout () {


### PR DESCRIPTION
Fixes #90 

[`Act.User.set_language`](https://valadoc.org/accountsservice/Act.User.set_language.html) requires a locale string in the form `en_GB.UTF-8`. We were previously just providing the language and country in the form `en_GB` or sometimes just the language (e.g. `ko`).

This method is used in the installer to set the languages and locales correctly, so we should do the same here.