### PR TITLE
Add additional US layout when non-latin layout is selected

### DIFF
--- a/src/Helpers/AccountsServiceInterface.vala
+++ b/src/Helpers/AccountsServiceInterface.vala
@@ -1,5 +1,5 @@
 [DBus (name = "io.elementary.SettingsDaemon.AccountsService")]
-interface Installer.AccountsService : Object {
+public interface Installer.AccountsService : Object {
     public struct KeyboardLayout {
         public string backend;
         public string name;

--- a/src/Helpers/LocaleHelper.vala
+++ b/src/Helpers/LocaleHelper.vala
@@ -17,30 +17,6 @@
  */
 
 namespace LocaleHelper {
-    [DBus (name = "org.freedesktop.locale1")]
-    interface Locale1 : Object {
-        [DBus (name = "SetLocale")]
-        public abstract void set_locale (string[] locale, bool user_interaction) throws GLib.Error;
-        [DBus (name = "SetVConsoleKeyboard")]
-        public abstract void set_vconsole_keyboard (string keymap, string keymap_toggle, bool convert, bool user_interaction) throws GLib.Error;
-        [DBus (name = "SetX11Keyboard")]
-        public abstract void set_x11_keyboard (string layout, string model, string variant, string options, bool convert, bool user_interaction) throws GLib.Error;
-        [DBus (name = "Locale")]
-        public abstract string[] locale { owned get; }
-        [DBus (name = "VConsoleKeymap")]
-        public abstract string vconsole_keymap { owned get; }
-        [DBus (name = "VConsoleKeymapToggle")]
-        public abstract string vconsole_keymap_toggle { owned get; }
-        [DBus (name = "X11Layout")]
-        public abstract string x11_layout { owned get; }
-        [DBus (name = "X11Model")]
-        public abstract string x11_model { owned get; }
-        [DBus (name = "X11Variant")]
-        public abstract string x11_variant { owned get; }
-        [DBus (name = "X11Options")]
-        public abstract string x11_options { owned get; }
-    }
-
     public class LangEntry {
         public string alpha_3;
         public string? alpha_2;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -126,14 +126,12 @@ public class Installer.MainWindow : Hdy.Window {
         }
 
         if (accounts_service != null) {
-            var layout = AccountsService.KeyboardLayout ();
-            layout.backend = "xkb";
-            layout.name = Configuration.get_default ().keyboard_layout;
+            var layouts = Configuration.get_default ().keyboard_layout.to_accountsservice_array ();
             if (Configuration.get_default ().keyboard_variant != null) {
-                layout.name += "+" + Configuration.get_default ().keyboard_variant;
+                layouts = Configuration.get_default ().keyboard_variant.to_accountsservice_array ();
             }
 
-            accounts_service.keyboard_layouts = { layout };
+            accounts_service.keyboard_layouts = layouts;
         }
     }
 }

--- a/src/Objects/Configuration.vala
+++ b/src/Objects/Configuration.vala
@@ -30,6 +30,6 @@ public class Configuration : GLib.Object {
 
     public string lang { get; set; }
     public string? country { get; set; default = null; }
-    public string keyboard_layout { get; set; }
-    public string? keyboard_variant { get; set; default = null; }
+    public InitialSetup.KeyboardLayout keyboard_layout { get; set; }
+    public InitialSetup.KeyboardVariant? keyboard_variant { get; set; default = null; }
 }

--- a/src/Objects/KeyboardLayout.vala
+++ b/src/Objects/KeyboardLayout.vala
@@ -18,6 +18,186 @@
  */
 
 public class InitialSetup.KeyboardLayout : GLib.Object {
+
+    // Based on https://github.com/mike-fabian/langtable/blob/master/langtable/data/keyboards.xml
+    public const string[] NON_LATIN_LAYOUTS = {
+        "af",
+        "af(fa-olpc)",
+        "af(olpc-ps)",
+        "af(ps)",
+        "af(uz)",
+        "af(uz-olpc)",
+        "am",
+        "am(eastern)",
+        "am(eastern-alt)",
+        "am(phonetic)",
+        "am(phonetic-alt)",
+        "am(western)",
+        "ara",
+        "ara(azerty)",
+        "ara(azerty_digits)",
+        "ara(buckwalter)",
+        "ara(digits)",
+        "ara(qwerty)",
+        "ara(qwerty_digits)",
+        "az(cyrillic)",
+        "bd",
+        "bd(probhat)",
+        "bg",
+        "bg(bas_phonetic)",
+        "bg(phonetic)",
+        "brai",
+        "brai(left_hand)",
+        "brai(right_hand)",
+        "bt",
+        "by",
+        "by(legacy)",
+        "ca(ike)",
+        "ca(multi-2gr)",
+        "cn(tib)",
+        "cn(tib_asciinum)",
+        "cn(ug)",
+        "cz(ucw)",
+        "de(ru)",
+        "et",
+        "fr(geo)",
+        "ge",
+        "ge(os)",
+        "gr",
+        "gr(extended)",
+        "gr(nodeadkeys)",
+        "gr(polytonic)",
+        "gr(simple)",
+        "il",
+        "il(biblical)",
+        "il(lyx)",
+        "il(phonetic)",
+        "in",
+        "in(ben)",
+        "in(ben_baishakhi)",
+        "in(ben_bornona)",
+        "in(ben_gitanjali)",
+        "in(ben_inscript)",
+        "in(ben_probhat)",
+        "in(bolnagri)",
+        "in(deva)",
+        "in(guj)",
+        "in(guru)",
+        "in(hin-kagapa)",
+        "in(hin-wx)",
+        "in(jhelum)",
+        "in(kan)",
+        "in(kan-kagapa)",
+        "in(mal)",
+        "in(mal_enhanced)",
+        "in(mal_lalitha)",
+        "in(mar-kagapa)",
+        "in(ori)",
+        "in(san-kagapa)",
+        "in(tam)",
+        "in(tam_TAB)",
+        "in(tam_TSCII)",
+        "in(tam_keyboard_with_numerals)",
+        "in(tam_unicode)",
+        "in(tel)",
+        "in(tel-kagapa)",
+        "in(urd-phonetic)",
+        "in(urd-phonetic3)",
+        "in(urd-winkeys)",
+        "iq",
+        "ir",
+        "ir(pes_keypad)",
+        "jp(kana)",
+        "jp(mac)",
+        "kg",
+        "kg(phonetic)",
+        "kh",
+        "kz",
+        "kz(kazrus)",
+        "kz(ruskaz)",
+        "la",
+        "la(stea)",
+        "lk",
+        "lk(tam_TAB)",
+        "lk(tam_unicode)",
+        "ma",
+        "ma(tifinagh)",
+        "ma(tifinagh-alt)",
+        "ma(tifinagh-alt-phonetic)",
+        "ma(tifinagh-extended)",
+        "ma(tifinagh-extended-phonetic)",
+        "ma(tifinagh-phonetic)",
+        "me(cyrillic)",
+        "me(cyrillicalternatequotes)",
+        "me(cyrillicyz)",
+        "mk",
+        "mk(nodeadkeys)",
+        "mm",
+        "mn",
+        "mv",
+        "ng(hausa)",
+        "ng(igbo)",
+        "ng(yoruba)",
+        "np",
+        "ph(capewell-dvorak-bay)",
+        "ph(capewell-qwerf2k6-bay)",
+        "ph(colemak-bay)",
+        "ph(dvorak-bay)",
+        "ph(qwerty-bay)",
+        "pk",
+        "pk(ara)",
+        "pk(snd)",
+        "pk(urd-crulp)",
+        "pk(urd-nla)",
+        "pl(ru_phonetic_dvorak)",
+        "rs",
+        "rs(alternatequotes)",
+        "rs(rue)",
+        "rs(yz)",
+        "ru",
+        "ru(bak)",
+        "ru(chm)",
+        "ru(cv)",
+        "ru(dos)",
+        "ru(kom)",
+        "ru(legacy)",
+        "ru(mac)",
+        "ru(os_legacy)",
+        "ru(os_winkeys)",
+        "ru(phonetic)",
+        "ru(phonetic_winkeys)",
+        "ru(sah)",
+        "ru(srp)",
+        "ru(tt)",
+        "ru(typewriter)",
+        "ru(typewriter-legacy)",
+        "ru(udm)",
+        "ru(xal)",
+        "se(ru)",
+        "se(rus_nodeadkeys)",
+        "se(swl)",
+        "sy",
+        "sy(syc)",
+        "sy(syc_phonetic)",
+        "th",
+        "th(pat)",
+        "th(tis)",
+        "tj",
+        "tj(legacy)",
+        "tz",
+        "ua",
+        "ua(homophonic)",
+        "ua(legacy)",
+        "ua(phonetic)",
+        "ua(rstu)",
+        "ua(rstu_ru)",
+        "ua(typewriter)",
+        "ua(winkeys)",
+        "us(chr)",
+        "us(rus)",
+        "uz"
+    };
+
     public string name { get; construct; }
     public string original_name { get; construct; }
     public string display_name {
@@ -51,7 +231,29 @@ public class InitialSetup.KeyboardLayout : GLib.Object {
     }
 
     public GLib.Variant to_gsd_variant () {
-        return new GLib.Variant ("(ss)", "xkb", name);
+        if (!(name in NON_LATIN_LAYOUTS)) {
+            // Layout can type latin characters, return a single layout
+            return new GLib.Variant.array (new VariantType ("(ss)"), { new GLib.Variant ("(ss)", "xkb", name) });
+        } else {
+            // User's layout doesn't use latin characters, also add US layout so they can type a username and password
+            var en_us = new GLib.Variant ("(ss)", "xkb", "us");
+            var primary_layout = new GLib.Variant ("(ss)", "xkb", name);
+            return new GLib.Variant.array (new VariantType ("(ss)"), { en_us, primary_layout });
+        }
+    }
+
+    public Installer.AccountsService.KeyboardLayout[] to_accountsservice_array () {
+        if (!(name in NON_LATIN_LAYOUTS)) {
+            // Layout can type latin characters, return a single layout
+            return {
+                Installer.AccountsService.KeyboardLayout () { backend = "xkb", name = name }
+            };
+        } else {
+            return {
+                Installer.AccountsService.KeyboardLayout () { backend = "xkb", name = "us" },
+                Installer.AccountsService.KeyboardLayout () { backend = "xkb", name = name }
+            };
+        }
     }
 
     public static int compare (KeyboardLayout a, KeyboardLayout b) {

--- a/src/Views/KeyboardLayoutView.vala
+++ b/src/Views/KeyboardLayoutView.vala
@@ -64,14 +64,13 @@ public class KeyboardLayoutView : AbstractInstallerView {
             if (row != null) {
                 var layout = ((LayoutRow) row).layout;
                 unowned Configuration configuration = Configuration.get_default ();
-                configuration.keyboard_layout = layout.name;
+                configuration.keyboard_layout = layout;
                 GLib.Variant? layout_variant = null;
-                string second_variant = layout.name;
 
                 unowned Gtk.ListBoxRow vrow = input_variant_widget.variant_listbox.get_selected_row ();
                 if (vrow != null) {
                     unowned InitialSetup.KeyboardVariant variant = ((VariantRow) vrow).variant;
-                    configuration.keyboard_variant = variant.name;
+                    configuration.keyboard_variant = variant;
                     if (variant != null) {
                         layout_variant = variant.to_gsd_variant ();
                     }
@@ -83,22 +82,9 @@ public class KeyboardLayoutView : AbstractInstallerView {
                     layout_variant = layout.to_gsd_variant ();
                 }
 
-                GLib.Variant list = new GLib.Variant.array (new VariantType ("(ss)"), { layout_variant });
                 var settings = new Settings ("org.gnome.desktop.input-sources");
-                settings.set_value ("sources", list);
+                settings.set_value ("sources", layout_variant);
                 settings.set_uint ("current", 0);
-
-                try {
-                    LocaleHelper.Locale1 locale1 = Bus.get_proxy_sync (
-                        BusType.SYSTEM,
-                        "org.freedesktop.locale1",
-                        "/org/freedesktop/locale1"
-                    );
-
-                    locale1.set_x11_keyboard (configuration.keyboard_layout, "", configuration.keyboard_variant ?? "", "", true, true);
-                } catch (Error e) {
-                    critical ("Unable to get Locale1 interface");
-                }
             }
         });
 
@@ -144,9 +130,9 @@ public class KeyboardLayoutView : AbstractInstallerView {
             var layout_string = "us";
             unowned Configuration config = Configuration.get_default ();
             if (config.keyboard_layout != null) {
-                layout_string = config.keyboard_layout;
+                layout_string = config.keyboard_layout.name;
                 if (config.keyboard_variant != null) {
-                    layout_string += "\t" + config.keyboard_variant;
+                    layout_string += "\t" + config.keyboard_variant.name;
                 }
             }
 


### PR DESCRIPTION
Fixes #99 

When a keyboard layout with non-latin characters is selected, it becomes impossible to progress past the following step, since the username field only accepts ASCII characters.

To remedy this, we add a list of non-latin keyboard layouts, taken from the excellent [langtable](https://github.com/mike-fabian/langtable) project, and whenever one of these layouts is selected, we also add an English (US) layout.

This allows typing a username and password using latin characters, and causes the wingpanel keyboard indicator to appear so you can switch between English (US) and the layout you chose to allow typing your full name if your native language for example.

I've also removed the Locale1 DBus calls for changing the layout as the greeter compositor handles this with Mutter.

The experience still isn't ideal as settings-daemon is being too clever and "remembering" the active layout in the session. So if you have your non-latin layout selected when you log out or reboot, then it will be selected the next time the greeter launches, meaning you have to manually switch back to the English layout to type your password. I think it would also be possible to delete the English layout in session, and it would be gone in the greeter too, leaving you unable to enter your password. So there's still a bit of work that needs to be done in the greeter and settings daemon probably.