### PR TITLE
Utils: Allow hyphens in the hostname

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -30,7 +30,7 @@ namespace Utils {
                 hostname += c.to_string ();
                 met_alpha = true;
                 whitespace_before = false;
-            } else if (c.isdigit () && met_alpha) {
+            } else if ((c.isdigit () || c == '-') && met_alpha) {
                 hostname += c.to_string ();
                 whitespace_before = false;
             } else if (c.isspace () && !whitespace_before) {


### PR DESCRIPTION
Currently hyphens in the hostname entry are removed, although they should be valid characters and actually we substitute them in behalf of whitespaces.

## Steps to test this branch
Maybe you should use virtual machines because we need to remove all users so that Initial Setup is shown in Greeter.

1. Install this branch
2. Enable root user with `sudo passwd root`
3. After reboot, switch to tty3, and log in with root
4. Run `userdel <user-name>` and remove all accounts
5. After reboot, Initial Setup should be shown. Then create a new user and here **use hyphens in the hostname**:
![set hostname with hyphens](https://user-images.githubusercontent.com/26003928/205054086-5fe00c53-b860-4cef-8b2b-2d2a6771a43e.png)

6. After log in, open Terminal and see the hyphens you used are included in the hostname:
![hostname with hyphens is applied](https://user-images.githubusercontent.com/26003928/205054100-1f0d3b98-d7ce-4601-b969-af75aee1bf6e.png)
