### PR TITLE
Remove semicolon at the end of polkit string

### DIFF
--- a/data/49-io.elementary.initial-setup.pkla
+++ b/data/49-io.elementary.initial-setup.pkla
@@ -7,7 +7,7 @@ ResultActive=yes
 
 [Host name]
 Identity=unix-user:lightdm
-Action=org.freedesktop.hostname1.set-hostname;org.freedesktop.hostname1.set-static-hostname;
+Action=org.freedesktop.hostname1.set-hostname;org.freedesktop.hostname1.set-static-hostname
 ResultAny=yes
 ResultInactive=yes
 ResultActive=yes


### PR DESCRIPTION
Addresses https://github.com/elementary/initial-setup/issues/182

From [reference manual](https://www.freedesktop.org/software/polkit/docs/0.105/pklocalauthority.8.html):
Action: A semi-colon separated list of globs to match action identifiers
No semicolon at the end of the examples